### PR TITLE
g3: remove deprecated cwm flag

### DIFF
--- a/system_prop.mk
+++ b/system_prop.mk
@@ -64,10 +64,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.data.qmi.adb_logmask=0 \
     ro.use_data_netmgrd=true
 
-# Recovery
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.cwm.forbid_format=/boot,/firmware,/mpt,/persist,/persist-lg,/sns
-
 # Sensors
 PRODUCT_PROPERTY_OVERRIDES += \
     debug.qualcomm.sns.daemon=e \


### PR DESCRIPTION
Change-Id: Icd91ed620421d051721dcbf1c02b4faba77928fd